### PR TITLE
Add ACS Task Notes Template

### DIFF
--- a/ACS-Task-Notes-Template.md
+++ b/ACS-Task-Notes-Template.md
@@ -1,0 +1,50 @@
+Title: {Area}-{Task} — {Task Title} (CFI Applicant Notes, ASEL)
+
+ACS Objective
+- {Paste the ACS objective for this Task}
+
+References (per ACS for this Task only)
+- {List the exact references cited in the ACS for this Task}
+
+Scope (ACS mapping)
+- Knowledge: {IDs and short labels}
+- Risk Management: {IDs and short labels}
+- Skills: {IDs and short labels}
+
+What I will teach (Knowledge)
+- Key concepts, definitions, models, and procedures from the listed references only.
+- Common errors relevant to this Task.
+
+How I will manage and teach risk (Risk Management)
+- Identify hazards specific to this Task.
+- Assess risk (likelihood/severity), using models from the references.
+- Mitigate: actions, decision points, triggers, alternatives.
+- Applicable ADM/CRM/SRM models (only those cited).
+
+How I will demonstrate skills and evaluate learning (Skills)
+- Demonstration-performance flow with ACS tolerances or completion standards.
+- Student role, monitoring, and my intervention triggers.
+- Checklists, flows, callouts, and positive exchange of controls (if applicable).
+
+Phase-of-instruction techniques (if applicable)
+- Preflight/dispatch, taxi, departure, enroute, approach/landing, postflight.
+
+Scenario-Based Training (SBT)
+- Scenario objective tied to the Task.
+- Variables/injects still within the listed references.
+- 3P/DECIDE/5P cycles where appropriate; go/no-go and knock-it-off criteria.
+
+Talk tracks (brief/execute/debrief)
+- Pre-brief script with decision points and controls exchange.
+- In-flight prompts (short, pre-briefed phraseology).
+- Debrief prompts (hazards, mitigations, outcomes, adjustments).
+
+Assessment plan
+- Authentic assessment tied to Knowledge, Risk, and Skills elements.
+- Sample oral prompts aligned with references.
+
+Quick-reference
+- Tools/models to use, always-brief/do/debrief bullets for this Task.
+
+Traceability
+- Map major teaching points to the cited references (title/section).


### PR DESCRIPTION
This file serves as a template for ACS task notes, outlining objectives, references, scope, teaching methods, risk management, skills evaluation, instructional techniques, scenario-based training, talk tracks, assessment plans, quick references, and traceability.